### PR TITLE
Namespace PSR-4 Standard

### DIFF
--- a/src/Provider/AgentServiceProvider.php
+++ b/src/Provider/AgentServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Shetabit\Visitor\Agent;
+namespace Shetabit\Visitor\Provider;
 
 use Illuminate\Support\ServiceProvider;
 use Shetabit\Agent\Agent;


### PR DESCRIPTION
The namespace of service provider was incorrect and not according to the PSR-4 standards. The current version installation will throw PSR error.