### PR TITLE
Fix: error when user agent is null

### DIFF
--- a/src/Drivers/JenssegersAgent.php
+++ b/src/Drivers/JenssegersAgent.php
@@ -68,7 +68,7 @@ class JenssegersAgent implements UserAgentParser
     {
         $parser = new Agent();
 
-        $parser->setUserAgent($this->request->userAgent());
+        $parser->setUserAgent($this->request->userAgent() ?? "N/A");
         $parser->setHttpHeaders((array)$this->request->headers);
 
         return $parser;

--- a/src/Drivers/UAParser.php
+++ b/src/Drivers/UAParser.php
@@ -77,6 +77,6 @@ class UAParser implements UserAgentParser
      */
     protected function initParser(): \UAParser\Result\Client
     {
-        return Parser::create()->parse($this->request->userAgent());
+        return Parser::create()->parse($this->request->userAgent() ?? "N/A");
     }
 }


### PR DESCRIPTION
Fix error in two driver when user agent is null 

`UAParser\Parser::parse(): Argument #1 ($userAgent) must be of type string, null given, called in .../vendor/shetabit/visitor/src/Drivers/UAParser.php on line 80`

`Detection\MobileDetect::setUserAgent(): Argument #1 ($userAgent) must be of type string, null given, called in .../vendor/shetabit/visitor/src/Drivers/JenssegersAgent.php on line 71`