### PR TITLE
Add support for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     ],
     "require": {
         "php": ">=8.0",
-        "illuminate/support": "9.*|10.*|11.*",
+        "illuminate/support": "9.*|10.*|11.*|12.*",
         "ua-parser/uap-php": "^3.9",
         "mobiledetect/mobiledetectlib": "^4.8",
         "jaybizzle/crawler-detect": "^1.2"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "phpunit/phpunit": ">=7.5",
         "squizlabs/php_codesniffer": "^3.4"
     },


### PR DESCRIPTION
Fixes #63

This PR adds compatibility with Laravel 12 by updating the version constraints in composer.json.

Changes:
- Updated illuminate/support to include ^12.0
- Updated orchestra/testbench to include ^10.0