### PR TITLE
Fix Agent::__call signature for mobiledetectlib 4.10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=8.0",
         "illuminate/support": "9.*|10.*|11.*|12.*|^13.0",
         "ua-parser/uap-php": "^3.9",
-        "mobiledetect/mobiledetectlib": ">=4.8 <4.9",
+        "mobiledetect/mobiledetectlib": "^4.10",
         "jaybizzle/crawler-detect": "^1.2"
     },
     "require-dev": {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -355,7 +355,7 @@ class Agent extends MobileDetect
     /**
      * @inheritdoc
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments): bool
     {
         // Make sure the name starts with 'is', otherwise
         if (!str_starts_with($name, 'is')) {


### PR DESCRIPTION
- Updates `Agent::__call` to use the typed signature `(string $name, array $arguments): bool` so it remains compatible with `Detection\MobileDetect::__call`, which became typed in `mobiledetect/mobiledetectlib` 4.10.0.
- Bumps the `mobiledetect/mobiledetectlib` constraint from `>=4.8 <4.9` to `^4.10` so installs resolve a parent class whose signature matches the override.

Fixes #76.